### PR TITLE
Use CMID (course module id) instead of id to find assignments.

### DIFF
--- a/grader.py
+++ b/grader.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
     parser.add_argument(
         "-c", "--courseid", help="Limit to this course ID only.", default=[], action='append')
     parser.add_argument("-a", "--assignmentid",
-                        help="Limit to this assignment ID only.", default=[], action='append')
+                        help="Limit to this assignment CMID only.", default=[], action='append')
     parser.add_argument("-g", "--gradableonly",
                         help="Limit to assignments you have grading rights for.", default=False, action="store_true")
     args = parser.parse_args()

--- a/grader.py
+++ b/grader.py
@@ -70,9 +70,9 @@ if __name__ == '__main__':
     parser.add_argument(
         "-o", "--overview", help="No grading, just give an overview.", default=False, action="store_true")
     parser.add_argument(
-        "-c", "--courseid", help="Limit to this course ID only.", default=[], action='append')
+        "-c", "--courseid", help="Limit to this course ID (check view.php?id=...).", default=[], action='append')
     parser.add_argument("-a", "--assignmentid",
-                        help="Limit to this assignment CMID only.", default=[], action='append')
+                        help="Limit to this assignment ID (check view.php?id=...).", default=[], action='append')
     parser.add_argument("-g", "--gradableonly",
                         help="Limit to assignments you have grading rights for.", default=False, action="store_true")
     args = parser.parse_args()

--- a/moodleteacher/__init__.py
+++ b/moodleteacher/__init__.py
@@ -203,6 +203,7 @@ class MoodleAssignment():
         else:
             self.deadline = self.duedate
         self.id = raw_json['id']
+        self.cmid = raw_json['cmid']
         self.name = raw_json['name']
         self.allows_feedback_comment = False
         for config in raw_json['configs']:
@@ -235,7 +236,7 @@ class MoodleAssignments(list):
             if (course_filter and course.id in course_filter) or not course_filter:
                 for ass_data in course_data['assignments']:
                     assignment = MoodleAssignment(conn, course, ass_data)
-                    if (assignment_filter and assignment.id in assignment_filter) or not assignment_filter:
+                    if (assignment_filter and assignment.cmid in assignment_filter) or not assignment_filter:
                         self.append(assignment)
 
 


### PR DESCRIPTION
The id parameter to view.php etc. is the CMID, not the id. So searching for cmid is more practical.

For reference, the relevant database tables are:

* mdl_course_modules(id, course, module, instance, ...). id is the cmid, module is a foreign key into the table of installed modules (activities, blocks etc), instance is the foreign key into the module's instance table

* mdl_assign(id, course, name, ...). id is the instance id

In the webservice, id is the primary key for mdl_assign, and cmid the primary key for mdl_course_modules. This indirection is necessary as different activity module use different table for storing their data.
