### PR TITLE
get may also return lists, not just post.

### DIFF
--- a/moodleteacher/__init__.py
+++ b/moodleteacher/__init__.py
@@ -84,7 +84,8 @@ class MoodleRequest():
         result = requests.get(self.conn.ws_url, params=self.ws_params)
         logging.debug("Result: " + str(result))
         result.raise_for_status()
-        if "exception" in result.json().keys():
+        data = result.json()
+        if isinstance(data, dict) and "exception" in data:
             raise Exception("Error response for Moodle web service GET request ('{message}')".format(**result.json()))
         return result
 
@@ -101,7 +102,7 @@ class MoodleRequest():
         result.raise_for_status()
         data = result.json()
         if isinstance(data, dict):
-            if "exception" in data.keys():
+            if "exception" in data:
                 raise Exception("Error response for Moodle web service POST request ('{message}')".format(**result.json()))
         return result
 


### PR DESCRIPTION
The library currently raises an exception if get returns a list, as it tries to check whether it was an error. It should process these similar to post.