### PR TITLE
Fix group submission grading if grouped mode is off.

### DIFF
--- a/moodleteacher/__init__.py
+++ b/moodleteacher/__init__.py
@@ -432,19 +432,19 @@ class MoodleSubmission():
     def save_grade(self, grade, feedback="", applytoall=True):
         # You can only give text feedback if your assignment is configured accordingly
         assert(feedback is "" or self.assignment.allows_feedback_comment)
-        if self.is_group_submission:
-            user_id = self.get_group_members()[0].id
-            applytoall = int(True)
+        if self.is_group_submission():
+            userid = self.get_group_members()[0].id
         else:
-            user_id = self.user_id
-            applytoall = int(False)
+            userid = self.userid
         params = {'assignmentid': self.assignment.id,
-                  'userid': user_id,
+                  'userid': userid,
                   'grade': float(grade),
                   'attemptnumber': -1,
                   'addattempt': int(True),
                   'workflowstate': self.GRADED,
-                  'applytoall': applytoall,
+                  # always apply grading to team
+                  # if the assignment has no group submission, this has no effect.
+                  'applytoall': int(True),
                   'plugindata[assignfeedbackcomments_editor][text]': str(feedback),
                   # //content format (1 = HTML, 0 = MOODLE, 2 = PLAIN or 4 = MARKDOWN)
                   'plugindata[assignfeedbackcomments_editor][format]': 2


### PR DESCRIPTION
If group submissions are enabled, but group mode is off, then groupid is 0 for all submissions (whether students belong to a team or not). This fixes it by always setting "apply to all".